### PR TITLE
Fix e09b4_even_odd_sums.py to match text problem and add related UT

### DIFF
--- a/ch03-lists-tuples/e09b4_even_odd_sums.py
+++ b/ch03-lists-tuples/e09b4_even_odd_sums.py
@@ -4,16 +4,16 @@
 
 def even_odd_sums(numbers):
     """Takes a list of numbers, and returns a two-element
-list containing the sum of the even elements and the
-sum of the odd elements.
+list containing the sum of the even-indexed elements and the
+sum of the odd-indexed elements.
 """
     evens = []
     odds = []
 
-    for one_number in numbers:
-        if one_number % 2:
-            odds.append(one_number)
-        else:
-            evens.append(one_number)
+    for num in numbers[::2]:
+        evens.append(num)
+
+    for num in numbers[1::2]:
+        odds.append(num)
 
     return [sum(evens), sum(odds)]

--- a/ch03-lists-tuples/test_e09b4_evenoddsums.py
+++ b/ch03-lists-tuples/test_e09b4_evenoddsums.py
@@ -1,0 +1,12 @@
+from e09b4_even_odd_sums import even_odd_sums
+import pytest
+
+
+@pytest.mark.parametrize('arg, output', [
+    ([10, 20, 30,40,50,60], [90, 120]),
+    ([10, 20, 30, 40, 50], [90, 60]),
+    ((10, -20, -30, 40), (-20, 20)),
+    ([10], [10])
+])
+def test_evenoddsums(arg, output):
+    assert even_odd_sums(arg) == output


### PR DESCRIPTION
Text problem says:
Write a function that takes a list or tuple of numbers. Return a two-element list, containing (respectively) the sum of the even-indexed numbers and the sum of the odd-indexed numbers. So calling the function as even_odd_sums([10, 20, 30,40,50,60]), you’ll get back[90,120].

Current solution does not look at index; rather looks at whether number itself is odd or even.